### PR TITLE
Specify convolution type="open" in convolve()

### DIFF
--- a/R/specifydesign.R
+++ b/R/specifydesign.R
@@ -59,16 +59,16 @@ function(onsets, durations, totaltime, TR, effectsize, accuracy=0.1, conv=c("non
 		if(conv=="gamma"){
 			s <- stimfunction(totaltime, onsets[[i]], durations[[i]], accuracy)
 		    if(!is.null(param)){
-			s.conv <- convolve(gammaHRF(seq(accuracy,totaltime,accuracy), param[[i]], verbose=FALSE), rev(s))
+			s.conv <- convolve(gammaHRF(seq(accuracy,totaltime,accuracy), param[[i]], verbose=FALSE), rev(s), type="open")
 		    }else{
-			s.conv <- convolve(gammaHRF(seq(accuracy,totaltime,accuracy), verbose=FALSE), rev(s))
+			s.conv <- convolve(gammaHRF(seq(accuracy,totaltime,accuracy), verbose=FALSE), rev(s), type="open")
 		    }
 			s.conv <- s.conv/max(s.conv)
 			design.matrix[,i] <- effectsize[[i]]*s.conv[ix]
 		}
 		if(conv=="double-gamma"){
                         s <- stimfunction(totaltime, onsets[[i]], durations[[i]], accuracy)
-                        s.conv <- convolve(canonicalHRF(seq(accuracy,totaltime,accuracy), param[[i]], verbose=FALSE), rev(s))
+                        s.conv <- convolve(canonicalHRF(seq(accuracy,totaltime,accuracy), param[[i]], verbose=FALSE), rev(s), type="open")
 			s.conv <- s.conv/max(s.conv)
                         design.matrix[,i] <- effectsize[[i]]*s.conv[ix]
  		}


### PR DESCRIPTION
The default setting for the convolution type in the convolve() function is set to circular (R Stats Package version 3.7.0), which leads to the unwanted effect that signals happening towards the end of the time sequence and exceeding it, are continued at the beginning due to being treated as periodic. 
See 

```
design <- simprepTemporal(totaltime=200, onsets=180,durations=40, effectsize=1, TR=2, hrf="double-gamma")
ts <- simTSfmri(design=design, SNR=1, noise="none")
plot(ts, type="l", xlab="Time", ylab="BOLD")
```

![grafik](https://user-images.githubusercontent.com/46441697/57377140-fd02c000-71a1-11e9-8b58-34679e2fbeef.png)




Setting the convolution type to "open" in the specifydesign() function solves this problem.

